### PR TITLE
Refactor: Make creating a logger easier

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -16,7 +16,7 @@ type redisClient interface {
 }
 
 // var logger = log.With().Str("namespace", "redis").Logger()
-var log = logger.New(nil).With().Str("namespace", "redis").Logger()
+var log = logger.New("redis")
 var redisInstance redisClient
 
 // Get returns the data stored under the given key.

--- a/dal/fetch.go
+++ b/dal/fetch.go
@@ -18,9 +18,9 @@ import (
 	"github.com/nickhstr/goweb/logger"
 )
 
-var log = logger.New(nil).With().Str("namespace", "dal").Logger()
+var log = logger.New("dal")
 
-// Use for getTTLFromResponse
+// Used for getTTLFromResponse
 var maxAgeRegex = regexp.MustCompile(`max-age=\d+`)
 
 // FetchConfig holds all the information needed by dal.Fetch() to make a request.

--- a/env/app.go
+++ b/env/app.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"os"
-
-	"github.com/rs/zerolog/log"
 )
 
 // DefaultAppName is the app's default name, set to the "GO_ENV" environment variable
@@ -25,9 +23,7 @@ func AppName(defaultNames ...string) string {
 		name = DefaultAppName
 	}
 
-	if err := os.Setenv("APP_NAME", name); err != nil {
-		log.Warn().Msg("Unable to set env var 'APP_NAME'")
-	}
+	_ = os.Setenv("APP_NAME", name)
 
 	return name
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -86,20 +86,20 @@ func TestEnvVarsToValidate(t *testing.T) {
 	c.Convey("Given environment variables to validate", t, func() {
 		vars := []string{"GO_ENV", "LOG_LEVEL"}
 
-		c.Convey("When they are set, and shouldPanic is true", func() {
+		c.Convey("When they are set", func() {
 			os.Setenv("GO_ENV", "test")
 			os.Setenv("LOG_LEVEL", "debug")
 
 			c.Convey("The variables should be valid", func() {
-				c.So(func() { env.ValidateEnvVars(vars, true) }, c.ShouldNotPanic)
+				c.So(env.ValidateEnvVars(vars), c.ShouldBeNil)
 			})
 		})
 
-		c.Convey("When one or more are not set, and shouldPanic is true", func() {
+		c.Convey("When one or more are not set", func() {
 			os.Unsetenv("GO_ENV")
 
-			c.Convey("ValidateEnvVars should panic", func() {
-				c.So(func() { env.ValidateEnvVars(vars, true) }, c.ShouldPanic)
+			c.Convey("ValidateEnvVars should return an error", func() {
+				c.So(env.ValidateEnvVars(vars), c.ShouldBeError)
 			})
 		})
 	})
@@ -107,7 +107,7 @@ func TestEnvVarsToValidate(t *testing.T) {
 	c.Convey("Given no variables to validate", t, func() {
 		c.Convey("When a nil slice is passed to ValidateEnvVars", func() {
 			c.Convey("It should do nothing", func() {
-				c.So(func() { env.ValidateEnvVars(nil, true) }, c.ShouldNotPanic)
+				c.So(env.ValidateEnvVars(nil), c.ShouldBeNil)
 			})
 		})
 	})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,13 +8,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// See https://golang.org/pkg/time/#pkg-constants for time layout rules
-const devTimeFormat = "2006/01/2 15:04:05"
-
 var rootLogger zerolog.Logger
 
 func init() {
-	rootLogger = zerolog.New(os.Stdout).
+	rootLogger = zerolog.New(getOutput()).
 		With().
 		Timestamp().
 		Logger()
@@ -47,10 +44,12 @@ func getLevel(logLevel string) zerolog.Level {
 }
 
 func getOutput() io.Writer {
+	// See https://golang.org/pkg/time/#pkg-constants for time layout rules
+	const devTimeFormat = "2006/01/2 15:04:05"
 	var out io.Writer
 
 	if !env.Prod() {
-		out = zerolog.ConsoleWriter{Out: os.Stdout}
+		out = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: devTimeFormat}
 	} else {
 		out = os.Stdout
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -3,73 +3,23 @@ package logger
 import (
 	"testing"
 
-	"github.com/rs/zerolog"
 	c "github.com/smartystreets/goconvey/convey"
 )
 
-func TestSetGlobalLevel(t *testing.T) {
-	c.Convey("Given a log level", t, func() {
-		var logLevel string
-
-		c.Convey("When it is a valid log level", func() {
-			logLevel = "debug"
-
-			c.Convey("The global log level should be set", func() {
-				setGlobalLevel(logLevel, "test")
-				globalLevel := zerolog.GlobalLevel()
-
-				c.So(globalLevel, c.ShouldEqual, zerolog.DebugLevel)
-			})
-		})
-
-		c.Convey("When it's not a valid level", func() {
-			logLevel = "invalid"
-
-			c.Convey("The global log level should be set to the environment's level", func() {
-				c.Convey("Production environment", func() {
-					setGlobalLevel(logLevel, "production")
-					globalLevel := zerolog.GlobalLevel()
-
-					c.So(globalLevel, c.ShouldEqual, zerolog.ErrorLevel)
-				})
-				c.Convey("Development environment", func() {
-					setGlobalLevel(logLevel, "development")
-					globalLevel := zerolog.GlobalLevel()
-
-					c.So(globalLevel, c.ShouldEqual, zerolog.InfoLevel)
-				})
-				c.Convey("Debug environment", func() {
-					setGlobalLevel(logLevel, "debug")
-					globalLevel := zerolog.GlobalLevel()
-
-					c.So(globalLevel, c.ShouldEqual, zerolog.DebugLevel)
-				})
-			})
-		})
-	})
-}
-
 func TestNew(t *testing.T) {
 	c.Convey("Given the need to create a new logger", t, func() {
-		c.Convey("When the config is nil", func() {
-			c.Convey("A new logger should be created with default settings", func() {
-				logger := New(nil)
+		c.Convey("A new logger should be created with default settings", func() {
+			logger := New("test")
 
-				// The *zerolog.Event returned from logger.Info() should be nil, as the
-				// default level is Error when the level is not specified.
-				c.So(logger.Info(), c.ShouldBeNil)
-			})
+			// The *zerolog.Event returned from logger.Info() should be nil, as the
+			// default level is Error when the level is not specified.
+			c.So(logger.Info(), c.ShouldBeNil)
+			c.So(logger.Error(), c.ShouldNotBeNil)
 		})
 
-		c.Convey("When the config has a level specified", func() {
-			config := &Config{Level: "info"}
-
+		c.Convey("When a level specified", func() {
 			c.Convey("A new logger should log at the given level", func() {
-				goodLog := New(config)
-				// Set the global level to one at the same level or a level less than the
-				// config's level. If this is not done, then a higher global level will
-				// prevent lower levels from being used.
-				zerolog.SetGlobalLevel(zerolog.InfoLevel)
+				goodLog := NewWithLevel("test", "info")
 
 				c.So(goodLog.Info(), c.ShouldNotBeNil)
 			})

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/nickhstr/goweb/env"
-	"github.com/rs/zerolog/log"
 )
 
 // Used to wrap an http.ResponseWriter to capture the response's status code

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/md5"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -57,7 +58,10 @@ func Create(config Config) http.Handler {
 		middleware = []Middleware{}
 	)
 
-	env.ValidateEnvVars(config.EnvVarsToValidate, true)
+	err := env.ValidateEnvVars(config.EnvVarsToValidate)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 
 	if config.Auth {
 		secretKey := env.Get("SECRET_KEY")

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,19 +3,22 @@ package middleware
 import (
 	"crypto/md5"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/nickhstr/goweb/env"
+	"github.com/nickhstr/goweb/logger"
+	"github.com/rs/zerolog"
 	"github.com/unrolled/secure"
 )
 
 var startTime time.Time
+var log zerolog.Logger
 
 func init() {
 	startTime = time.Now()
+	log = logger.New("middleware")
 }
 
 func uptime() time.Duration {
@@ -60,7 +63,8 @@ func Create(config Config) http.Handler {
 
 	err := env.ValidateEnvVars(config.EnvVarsToValidate)
 	if err != nil {
-		log.Fatal(err.Error())
+		// Log invalid env vars and exit
+		log.Fatal().Err(err).Msg("Invalid environment variables")
 	}
 
 	if config.Auth {

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -6,7 +6,6 @@ import (
 	"runtime/debug"
 
 	"github.com/nickhstr/goweb/env"
-	"github.com/rs/zerolog/log"
 )
 
 // Recover middleware recovers from panics, and logs the error.

--- a/newrelic/newrelic.go
+++ b/newrelic/newrelic.go
@@ -1,7 +1,6 @@
 package newrelic
 
 import (
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -10,7 +9,6 @@ import (
 	"github.com/nickhstr/goweb/env"
 	"github.com/nickhstr/goweb/logger"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -22,6 +20,7 @@ func init() {
 	enabled, _ := strconv.ParseBool(env.Get("NEW_RELIC_ENABLED", "false"))
 	appName := env.Get("NEW_RELIC_APP_NAME")
 	license := env.Get("NEW_RELIC_LICENSE_KEY")
+	log := logger.New("newrelic")
 
 	if !enabled {
 		return
@@ -98,27 +97,17 @@ func (l *nrLogger) DebugEnabled() bool {
 }
 
 // newLogger returns a custom logger which satisfies the newrelic Logger interface.
-func newLogger(w io.Writer) nr.Logger {
+func newLogger() nr.Logger {
 	logLevel := env.Get("NEW_RELIC_LOG_LEVEL", "error")
+	log := logger.NewWithLevel("newrelic", logLevel)
 
-	zlog := logger.New(&logger.Config{Level: logLevel})
-
-	return &nrLogger{zlog}
+	return &nrLogger{log}
 }
 
 func setupLog(c *nr.Config) {
 	logEnabled, _ := strconv.ParseBool(env.Get("NEW_RELIC_LOG_ENABLED", "false"))
 
 	if logEnabled {
-		logOut := env.Get("NEW_RELIC_LOG", "stdout")
-
-		switch logOut {
-		case "stderr":
-			c.Logger = newLogger(os.Stderr)
-		case "stdout":
-			fallthrough
-		default:
-			c.Logger = newLogger(os.Stdout)
-		}
+		c.Logger = newLogger()
 	}
 }

--- a/server/dnscache.go
+++ b/server/dnscache.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/rs/dnscache"
+)
+
+// DNSCache adds caching to dns lookups, performed by the standard library's http.DefaultClient.
+// TTL in this case doesn't truly mean TTL for an address; rather, it determines the number of
+// seconds to use for the cache refresh interval.
+func DNSCache(enable bool, ttl int) {
+	if !enable {
+		return
+	}
+
+	r := &dnscache.Resolver{}
+	http.DefaultTransport.(*http.Transport).
+		DialContext = func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := r.LookupHost(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ip := range ips {
+			var dialer net.Dialer
+			conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
+			if err == nil {
+				break
+			}
+		}
+		return
+	}
+
+	// Run refresh job in background
+	go func() {
+		t := time.NewTicker(time.Duration(ttl) * time.Second)
+		defer t.Stop()
+		for range t.C {
+			// Use true to refresh addresses not used since the last refresh
+			r.Refresh(true)
+		}
+	}()
+}


### PR DESCRIPTION
This makes creating new namespaced loggers easier, and more performant.
New loggers are created as children of a root logger, and there is no more usage of the global zerolog logger.