### PR TITLE
Refactor: No Etag Header for Error Status Codes

### DIFF
--- a/middleware/etag.go
+++ b/middleware/etag.go
@@ -28,6 +28,12 @@ func (e *EtagWriter) Flush() {
 }
 
 func (e *EtagWriter) Write(p []byte) (int, error) {
+	// Don't generate etag for error status codes
+	if e.status >= 400 {
+		e.ResponseWriter.WriteHeader(e.status)
+		return e.ResponseWriter.Write(p)
+	}
+
 	// `weak` should be true when the ResponseWriter is a Flusher, as that
 	// indicates the response body can be streamed
 	_, weak := e.ResponseWriter.(http.Flusher)

--- a/middleware/etag_test.go
+++ b/middleware/etag_test.go
@@ -1,0 +1,115 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/nickhstr/goweb/etag"
+	"github.com/nickhstr/goweb/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEtag(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		msg string
+		*http.Request
+		handler        http.Handler
+		expectedStatus int
+		expectedEtag   string
+	}{
+		{
+			"200 response should include an etag",
+			&http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Scheme: "http",
+					Host:   "foo.com",
+					Path:   "/good",
+				},
+				Header: http.Header{
+					"If-None-Match": []string{""},
+				},
+			},
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("all good here"))
+			}),
+			http.StatusOK,
+			etag.Generate([]byte("all good here"), true),
+		},
+		{
+			"400 response should not include an etag",
+			&http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Scheme: "http",
+					Host:   "foo.com",
+					Path:   "/notfound",
+				},
+				Header: http.Header{
+					"If-None-Match": []string{""},
+				},
+			},
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("not found"))
+			}),
+			http.StatusNotFound,
+			"",
+		},
+		{
+			"500 response should not include an etag",
+			&http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Scheme: "http",
+					Host:   "foo.com",
+					Path:   "/error",
+				},
+				Header: http.Header{
+					"If-None-Match": []string{""},
+				},
+			},
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("server error"))
+			}),
+			http.StatusInternalServerError,
+			"",
+		},
+		{
+			"200 response with matching if-none-match etag should return not modified status code",
+			&http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Scheme: "http",
+					Host:   "foo.com",
+					Path:   "/not-modified",
+				},
+				Header: http.Header{
+					"If-None-Match": []string{etag.Generate([]byte("content not modified"), true)},
+				},
+			},
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("content not modified"))
+			}),
+			http.StatusNotModified,
+			etag.Generate([]byte("content not modified"), true),
+		},
+	}
+
+	for _, test := range tests {
+		handler := middleware.Etag(test.handler)
+		respRec := httptest.NewRecorder()
+
+		handler.ServeHTTP(respRec, test.Request)
+		resp := respRec.Result()
+		e := resp.Header.Get("etag")
+
+		assert.Equal(test.expectedEtag, e, test.msg)
+		assert.Equal(test.expectedStatus, resp.StatusCode, test.msg)
+	}
+}


### PR DESCRIPTION
Responses with 400 and up status codes should not generate an etag.